### PR TITLE
Fixed methods

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run lint
+
+npm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "umob",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Umob modular utilities",
 	"browser": "lib/index.esm.js",
 	"module": "lib/index.esm.js",

--- a/src/__tests__/calculateDate.test.ts
+++ b/src/__tests__/calculateDate.test.ts
@@ -25,8 +25,12 @@ describe('calculateDate: ', () => {
         expect(calculateDate('2023-12-31', 1)).toEqual('2024-01-01')
     })
 
-    it('Time Date', () => {
+    it('Time Date1', () => {
         expect(calculateDate('2023/07/07 12:55:12', 32)).toEqual('2023-08-08')
+    })
+
+    it('Testing Date2', () => {
+        expect(calculateDate(new Date('2023-07-07'), 5)).toEqual('2023-07-12')
     })
 
     it('Testing format', () => {

--- a/src/calculateDate.ts
+++ b/src/calculateDate.ts
@@ -16,8 +16,9 @@ function calculateDate(
     fmt?: string,
 ): string {
     const date = toDate(inputDate)
+    const str = inputDate.toString()
 
-    if (isVaildDate(date)) {
+    if (isVaildDate(date) && str.length > 7) {
         date.setTime(date.getTime() + num * 24 * 3600 * 1000)
         return dateFormat(date, fmt)
     }

--- a/src/dateGap.ts
+++ b/src/dateGap.ts
@@ -21,9 +21,11 @@ function dateGap(startDate: any, endDate: any, opt: {
     const diffdate = []
     const sTime = toDate(startDate)
     const eTime = toDate(endDate)
+    const startDateLength = startDate.toString().length
+    const endDateLength = startDate.toString().length
     const { includeHead = true, includeTail = true, format = 'yyyy-MM-dd' } = opt
 
-    if (isVaildDate(sTime) && isVaildDate(eTime)) {
+    if (isVaildDate(sTime) && isVaildDate(eTime) && startDateLength > 7 && endDateLength > 7) {
         while (sTime < eTime) {
             diffdate.push(dateFormat(sTime, format))
             sTime.setTime(sTime.getTime() + 24 * 3600 * 1000)


### PR DESCRIPTION
Fixed methods：
1、dateGap - If length of startDate or endDate < 7,it will be regarded as month.
2、calculateDate - If length of date < 7,it will be regarded as month.